### PR TITLE
Windows-fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.js
+++ b/index.js
@@ -1,7 +1,11 @@
 var scope = {
-	pdfbox : __dirname + "/bin/pdfbox-app-1.7.1.jar"
+	pdfbox : __dirname + "/bin/pdfbox-app-1.8.9.jar"
 }
 
 module.exports.PDFSplit = function(){
-	require('./lib/PDFSplit').apply(scope, arguments)
+	return require('./lib/PDFSplit').apply(scope, arguments)
+};
+
+module.exports.PDFMerger = function(){
+	return require('./lib/PDFMerger').apply(scope, arguments)
 };

--- a/lib/PDFMerger.js
+++ b/lib/PDFMerger.js
@@ -9,9 +9,9 @@ module.exports = function(files, outputFile) {
 		'-jar',
 		this.pdfbox,
 		'PDFMerger',
-	].concat(files.map(function (file) { return "'" + file + "'"}))
+	].concat(files.map(function (file) { return '"' + file + '"'}))
 
-  command.push("'" + outputFile + "'")
+  command.push('"' + outputFile + '"')
 
 	return exec(command.join(' '));
 }

--- a/lib/PDFMerger.js
+++ b/lib/PDFMerger.js
@@ -1,0 +1,20 @@
+var Promise = require('bluebird');
+
+var exec = Promise.promisify(require('child_process').exec);
+
+module.exports = function(files, outputFile) {
+  console.log("OUTPUT FILE: " + outputFile)
+
+	var command = [
+		'java',
+		'-jar',
+		this.pdfbox,
+		'PDFMerger',
+	].concat(files)
+
+  command.push(outputFile)
+
+  console.log(command.join(' '))
+
+	return exec(command.join(' '));
+}

--- a/lib/PDFMerger.js
+++ b/lib/PDFMerger.js
@@ -10,9 +10,9 @@ module.exports = function(files, outputFile) {
 		'-jar',
 		this.pdfbox,
 		'PDFMerger',
-	].concat(files)
+	].concat(files.map(function (file) { return "'" + file + "'"}))
 
-  command.push(outputFile)
+  command.push("'" + outputFile + "'")
 
   console.log(command.join(' '))
 

--- a/lib/PDFMerger.js
+++ b/lib/PDFMerger.js
@@ -3,7 +3,6 @@ var Promise = require('bluebird');
 var exec = Promise.promisify(require('child_process').exec);
 
 module.exports = function(files, outputFile) {
-  console.log("OUTPUT FILE: " + outputFile)
 
 	var command = [
 		'java',
@@ -13,8 +12,6 @@ module.exports = function(files, outputFile) {
 	].concat(files.map(function (file) { return "'" + file + "'"}))
 
   command.push("'" + outputFile + "'")
-
-  console.log(command.join(' '))
 
 	return exec(command.join(' '));
 }

--- a/lib/PDFSplit.js
+++ b/lib/PDFSplit.js
@@ -1,21 +1,16 @@
-var exec = require('child_process').exec;
+var Promise = require('bluebird');
 
-module.exports = function(data, callback){
-	
+var exec = Promise.promisify(require('child_process').exec);
+
+module.exports = function(file) {
+
 	var command = [
 		'java',
 		'-jar',
 		this.pdfbox,
 		'PDFSplit',
-		data.file
+		file
 	];
 
-	exec(command.join(' '), function (err, stdout, stderr) {
-		if (callback) {
-			callback(err, stdout, stderr);
-		} 
-		else {
-			if (err) throw new Error(err);
-		}
-	});
+	return exec(command.join(' '));
 }

--- a/package.json
+++ b/package.json
@@ -3,11 +3,13 @@
   "description": "Wrapper for pdfbx",
   "version": "0.0.1",
   "author": "Paul Nordmann",
-  "repository" :    { 
-    "type" :  "git", 
-    "url" :   "https://github.com/Klab-Berlin/node-pdfbox.git" 
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Klab-Berlin/node-pdfbox.git"
   },
-  "dependencies": {},
+  "dependencies": {
+    "bluebird": "^2.9.24"
+  },
   "devDependencies": {},
-  "engine": "node = 0.10.13"
+  "engine": "node = 0.12.0"
 }


### PR DESCRIPTION
Windows isn't happy with single-quotation marks.

This fixes it, but might break on nix.

Alternatively we could run a function like this on files.

```
_shellPath = function (file) {
    if (process.platform === 'win32') {
        return file;
    } else {
        return "'" + file + "'";
    }
}
```

EG:
`command.push(_shellPath(outputFile));`
